### PR TITLE
Disable OpenQA::Test::TimeLimit by ENV variable or when running within debugger

### DIFF
--- a/lib/OpenQA/Test/TimeLimit.pm
+++ b/lib/OpenQA/Test/TimeLimit.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright (C) 2020-2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,7 +21,8 @@ my $SCALE_FACTOR = 1;
 sub import {
     my ($package, $limit) = @_;
     die "$package: Need argument on import, e.g. use: use OpenQA::Test::TimeLimit '42';" unless $limit;
-    return if $ENV{OPENQA_TEST_TIMEOUT_DISABLE};
+    # disable timeout if requested by ENV variable or running within debugger
+    return if ($ENV{OPENQA_TEST_TIMEOUT_DISABLE} or $DB::single);
     $SCALE_FACTOR *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_COVER} // 3 if Devel::Cover->can('report');
     $SCALE_FACTOR *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_CI}    // 2 if $ENV{CI};
     $limit        *= $SCALE_FACTOR;


### PR DESCRIPTION
* Disable OpenQA::Test::TimeLimit when running within debugger
* Add option to disable test timeout with env variable