### PR TITLE
Mention which test timed out in case the test runner does not

### DIFF
--- a/lib/OpenQA/Test/TimeLimit.pm
+++ b/lib/OpenQA/Test/TimeLimit.pm
@@ -26,7 +26,7 @@ sub import {
     $SCALE_FACTOR *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_COVER} // 3 if Devel::Cover->can('report');
     $SCALE_FACTOR *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_CI}    // 2 if $ENV{CI};
     $limit        *= $SCALE_FACTOR;
-    $SIG{ALRM} = sub { BAIL_OUT "test exceeds runtime limit of '$limit' seconds\n" };
+    $SIG{ALRM} = sub { BAIL_OUT "test '$0' exceeds runtime limit of '$limit' seconds\n" };
     alarm $limit;
 }
 


### PR DESCRIPTION
Example output:

```
t/18-qemu.t .. 1/? Bailout called.  Further testing stopped:  test 't/18-qemu.t' exceeds runtime limit of '1' seconds
FAILED--Further testing stopped: test 't/18-qemu.t' exceeds runtime limit of '1' seconds
```

in other cases the first mention of "t/18-qemu.t" would not show so this
commit ensures that the name is mentioned in the error message.

Related progress issue: https://progress.opensuse.org/issues/97241