### PR TITLE
commit message: allow non whitespace in subject

### DIFF
--- a/.github/workflows/commit_message_checker.yml
+++ b/.github/workflows/commit_message_checker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Check Subject Begining
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^([A-Z]|[A-Za-z0-9_/.]+:)'
+          pattern: '^([A-Z]|\S+:)'
           flags: 'g'
           error: 'The subject does not start with a capital or tag.'
           excludeDescription: 'true'


### PR DESCRIPTION
Commit messages describing functions, e.g.: `testapi/save_screenshot(): Bar foo in baz` or `select_serial_terminal(): Lorem Ipsum` are perfectly valid names. Instead of being picky what characters are allowed in the tag, let's just require not have whitespace before column.