### PR TITLE
Reusable Workflow Experiment: Upstreaming commit message checks

### DIFF
--- a/.github/workflows/base-commit-message-checker.yml
+++ b/.github/workflows/base-commit-message-checker.yml
@@ -1,50 +1,52 @@
 ---
-# https://github.com/marketplace/actions/gs-commit-message-checker
 name: 'Commit message check'
-# yamllint disable-line rule:truthy
+
 on:
-  pull_request:
-  push:
-    branches:
-      - '!master'  # we must not fix commit messages when they already reached master
+  workflow_call:
+    secrets:
+      accessToken:
+        required: true
 
 jobs:
-  check-commit-message:
+  base-check-commit-message:
     name: Check commit message
     runs-on: ubuntu-latest
     steps:
       - name: Check subject beginning
-        uses: gsactions/commit-message-checker@v1
+        uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^([A-Z]|[A-Za-z0-9_/.\-\s]+:|git subrepo pull)'
+          pattern: '^([A-Z]|\S+:|git subrepo pull)'
           flags: 'g'
           error: 'The subject does not start with a capital or tag.'
           excludeDescription: 'true'
           excludeTitle: 'true'
           checkAllCommitMessages: 'true'
-          accessToken: ${{ secrets.GITHUB_TOKEN }}
+          accessToken: ${{ secrets.accessToken }}
+
       - name: Check subject line length
-        uses: gsactions/commit-message-checker@v1
+        uses: gsactions/commit-message-checker@v2
         with:
           pattern: '^.{1,72}(\n|$)'
           flags: 'g'
           error: 'The maximum subject line length of 72 characters is exceeded.'
-          excludeDescription: 'true'    # excludes the description body of a pull request
-          excludeTitle: 'true'    # excludes the title of a pull request
-          checkAllCommitMessages: 'true'    # checks all commits associated with a pull request
-          accessToken: ${{ secrets.GITHUB_TOKEN }}    # only required if checkAllCommitMessages is true
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.accessToken }}
+
       - name: Check subject ending
         uses: gsactions/commit-message-checker@v2
         with:
           pattern: '^.+(?<!\.)(\n|$)'
           flags: 'g'
-          error: 'The subject cannot end with a dot.'
+          error: 'The subject cannot not end with a dot.'
           excludeDescription: 'true'
           excludeTitle: 'true'
           checkAllCommitMessages: 'true'
-          accessToken: ${{ secrets.GITHUB_TOKEN }}
+          accessToken: ${{ secrets.accessToken }}
+
       - name: Check empty line
-        uses: gsactions/commit-message-checker@v1
+        uses: gsactions/commit-message-checker@v2
         with:
           pattern: '^.*(\n\n|$)'
           flags: 'g'
@@ -52,4 +54,4 @@ jobs:
           excludeDescription: 'true'
           excludeTitle: 'true'
           checkAllCommitMessages: 'true'
-          accessToken: ${{ secrets.GITHUB_TOKEN }}
+          accessToken: ${{ secrets.accessToken }}

--- a/.github/workflows/commit-message-checker.yml
+++ b/.github/workflows/commit-message-checker.yml
@@ -1,0 +1,15 @@
+---
+name: 'Commit message check'
+
+on:
+  pull_request:
+  push:
+    branches:
+      # we must not fix commit messages when they already reached master
+      - '!master'
+
+jobs:
+  check-commit-message:
+    secrets:
+      accessToken: "${{ secrets.GITHUB_TOKEN }}"
+    uses: ./.github/workflows/base-commit-message-checker.yml


### PR DESCRIPTION
- Bringing checks from os-autoinst/openQA#5343.
- Setting up reusable workflows [0].

[0]: https://docs.github.com/en/actions/using-workflows/reusing-workflows.

This is an experiment :lab_coat: 

First Error:

![image](https://github.com/os-autoinst/os-autoinst-common/assets/5963207/02638d7b-54a6-492e-950a-7a0eaf228686)

---

There's a successful schedule of the check: https://github.com/os-autoinst/os-autoinst-common/actions/runs/6626891884

---

Proposed Agreement:

- Define all checks as `base-%{check-name}.yml` into `.github/workflows`.
- Use them in `%{check-name}.yml` in `.github/workflows`.
- Make PR's in each derived repo so the workflow is used instead of re-defined. See the snippet below:

Reusable Workflow usage on downstream repos:

```yaml
---
name: 'Commit Message Check'

on:
  pull_request:
  push:
    branches:
      # we must not fix commit messages when they already reached master
      - '!master'

jobs:
  call-check-commit-message:
    uses: os-autoinst/os-autoinst-common./.github/workflows/base-commit-message-checker.yml@master
    secrets:
      accessToken: "${{ secrets.GITHUB_TOKEN }}"
```
