### PR TITLE
Add YAML-Lint checks

### DIFF
--- a/.github/workflows/base-commit-message-checker.yml
+++ b/.github/workflows/base-commit-message-checker.yml
@@ -1,7 +1,6 @@
 ---
 name: 'Commit message check'
 
-# yamllint disable-line rule:truthy
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/commit-message-checker.yml
+++ b/.github/workflows/commit-message-checker.yml
@@ -1,7 +1,6 @@
 ---
 name: 'Commit message check'
 
-# yamllint disable-line rule:truthy
 on:
   pull_request:
   push:

--- a/.github/workflows/perl-critic.yml
+++ b/.github/workflows/perl-critic.yml
@@ -1,7 +1,6 @@
 ---
 name: 'Perl critic'
 
-# yamllint disable-line rule:truthy
 on:
   pull_request:
   push:

--- a/.github/workflows/perl-lint-checks.yml
+++ b/.github/workflows/perl-lint-checks.yml
@@ -1,7 +1,6 @@
 ---
 name: 'Perl static checks'
 
-# yamllint disable-line rule:truthy
 on:
   pull_request:
   push:

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,19 @@
+---
+name: 'YAML-lint'
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  yaml-lint:
+    runs-on: ubuntu-latest
+    name: "YAML-lint"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker://registry.opensuse.org/home/okurz/container/containers/tumbleweed:yamllint
+        with:
+          entrypoint: yamllint
+          args: -c .yamllint --strict ./ --format github

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,25 @@
+extends: default
+ignore-from-file: [.gitignore, .yamlignore]
+
+rules:
+  line-length:
+    max: 160
+  document-start: disable
+  indentation:
+    indent-sequences: true
+    spaces: 2
+
+  # Allows aligning subsequent lines with [] sequences
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: -1
+  commas:
+    max-spaces-after: -1
+
+  # Allows aligning key value pairs
+  colons:
+    max-spaces-after: -1
+
+  truthy:
+    allowed-values: ['true', 'false']
+    check-keys: false


### PR DESCRIPTION
- Pulled configs from openQA
- Removed `yamllint disable-line` comments
- It can interop with downstream repositories using the .yamllint config
  on them.
- Contributes to [poo#138416][0]

[0]: https://progress.opensuse.org/issues/138416