### PR TITLE
Properly handle Scheduled routines with SpaceAfterSubroutineName

### DIFF
--- a/lib/perlcritic/Perl/Critic/Policy/SpaceAfterSubroutineName.pm
+++ b/lib/perlcritic/Perl/Critic/Policy/SpaceAfterSubroutineName.pm
@@ -24,30 +24,56 @@ sub applies_to { 'PPI::Statement::Sub' }
 
 # check that use strict/warnings is not present when equivalent modules are.
 sub violates ($self, $elem, $doc) {
-    # Grep the first 7 tokens:
-    # Case 1: bare sub
-    #   0. literal "sub"
-    #   1. :space: # must be 1
-    #   2. sub_name
-    #   3. :space: # must be 1
-    #   4. block/structure
-    # Case 2: sub with prototype/signature
-    #   0. literal "sub"
-    #   1. :space: # must be 1
-    #   2. sub_name
-    #   3. :space: # must be 1
-    #   4. prototype
-    #   5. :space: # must be 1
-    #   6. block/structure
-
+    # Grep the first 7 tokens: each function will validate the cases.
     my @tokens = ($elem->tokens())[0 .. 6];
-    return $self->violation($DESC, sprintf($EXPL, $elem->name), $elem) unless _is_surrounded_by_one_space($tokens[2]);
 
-    return () if $tokens[4]->isa('PPI::Token::Structure');
+    return () if $elem->forward();
+    return $self->check_reserved_sub($elem, @tokens) if _is_reserved_sub($elem);
+    return $self->check_classic_sub($elem, @tokens) unless defined($elem->prototype);
+    return $self->check_complete_sub($elem, @tokens);
+}
 
-    return $self->violation($DESC, sprintf($EXPL, $elem->name), $elem) unless _is_surrounded_by_one_space($tokens[4]);
+sub report_violation ($self, $elem) {
+    return $self->violation($DESC, sprintf($EXPL, $elem->name), $elem);
+}
 
-    return ();
+sub check_reserved_sub ($self, $elem, @tokens) {
+    # "Reserved Sub" token desired layout
+    # 0. Word - END/BEGIN/etc.
+    # 1. Whitespace
+    # 2. Structure - the actual code block.
+    return () if _is_only_one_space($tokens[1]) && _is_block($tokens[2]);
+    return $self->report_violation($elem);
+}
+
+sub check_classic_sub ($self, $elem, @tokens) {
+    # "Classic Sub" token desired layout
+    #   0. Word "sub"
+    #   1. Whitespace - must be 1
+    #   2. Word - the sub name
+    #   3. Whitespace - must be 1
+    #   4. Structure - the actual code block
+
+    return () if _is_surrounded_by_one_space($tokens[2]);
+    return $self->report_violation($elem);
+}
+
+sub check_complete_sub ($self, $elem, @tokens) {
+    # "Complete Sub" token desired layout
+    #   0. Word "sub"
+    #   1. Whitespace - must be 1
+    #   2. Word - the sub name
+    #   3. Whitespace - must be 1
+    #   4. Prototype - sub's prototype/signature
+    #   5. Whitespace - must be 1
+    #   6. Structure - the actual code block
+
+    return () if _is_surrounded_by_one_space($tokens[2]) && _is_surrounded_by_one_space($tokens[4]);
+    return $self->report_violation($elem);
+}
+
+sub _is_block ($token) {
+    return $token->isa('PPI::Token::Structure');
 }
 
 sub _is_only_one_space ($token) {
@@ -56,6 +82,10 @@ sub _is_only_one_space ($token) {
 
 sub _is_surrounded_by_one_space ($token) {
     return _is_only_one_space($token->previous_sibling) && _is_only_one_space($token->next_sibling);
+}
+
+sub _is_reserved_sub ($elem) {
+    return $elem->isa('PPI::Statement::Scheduled');
 }
 
 1;


### PR DESCRIPTION
- The rule now handles reserved SUB's (END, BEGIN, & friends) correctly.
- Documented the token layout for each case.

Supports [poo#138416](https://progress.opensuse.org/issues/138416)