### PR TITLE
Reduce severity for useless quotes

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -42,7 +42,7 @@ severity = 1
 # == Custom Policies
 # -- Useless quotes on hashes
 [HashKeyQuotes]
-severity = 5
+severity = 3
 
 # -- Superfluous use strict/warning.
 [RedundantStrictWarning]


### PR DESCRIPTION
This allows unnecessary changes in the definition of some keys in hashes. The special character do not behave without the quotes so we reduce the severity of this rule and make the checks green. This affects mainly openQA but we keep it common for all repos.