### PR TITLE
Ensure to run the same perltidy versions as downstream projects

### DIFF
--- a/.github/workflows/perl-lint-checks.yml
+++ b/.github/workflows/perl-lint-checks.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Perltidy"
     container:
-      image: perldocker/perl-tester
+      image: registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
     steps:
       - uses: actions/checkout@v4
       - run: GITHUB_ACTIONS=1 ./tools/tidyall --check-only --all --quiet

--- a/cpanfile
+++ b/cpanfile
@@ -17,7 +17,7 @@ on 'develop' => sub {
     requires 'Code::TidyAll';
     requires 'Perl::Critic';
     requires 'Perl::Critic::Community';
-    requires 'Perl::Tidy', '== 20240202';
+    requires 'Perl::Tidy', '== 20230912';
 
 };
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -17,7 +17,7 @@ main_requires:
   perl(Module::CPANfile):
 
 develop_requires:
-  perl(Perl::Tidy): '== 20240202'
+  perl(Perl::Tidy): '== 20230912'
   perl(Code::TidyAll):
   perl(Perl::Critic):
   perl(Perl::Critic::Community):


### PR DESCRIPTION
By using our os-autoinst_dev container for running perltidy same as in e.g.
os-autoinst or openQA we are running the same perltidy version as in there.
This fixes the problem that a new release of Perl::Tidy on CPAN would bring in
a need to update to the new version whereas in downstream projects we are
relying on the version that is in openSUSE Tumbleweed and Leap.