### PR TITLE
Provide Makefile targets for additional checks

### DIFF
--- a/.github/workflows/perl-critic.yml
+++ b/.github/workflows/perl-critic.yml
@@ -11,4 +11,4 @@ jobs:
       image: perldocker/perl-tester
     steps:
       - uses: actions/checkout@v4
-      - run: ./tools/perlcritic --quiet .
+      - run: make test-critic

--- a/.github/workflows/perl-lint-checks.yml
+++ b/.github/workflows/perl-lint-checks.yml
@@ -11,4 +11,4 @@ jobs:
       image: registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
     steps:
       - uses: actions/checkout@v4
-      - run: GITHUB_ACTIONS=1 ./tools/tidyall --check-only --all --quiet
+      - run: GITHUB_ACTIONS=1 make test-tidy

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -11,5 +11,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker://registry.opensuse.org/home/okurz/container/containers/tumbleweed:yamllint
         with:
-          entrypoint: yamllint
-          args: -c .yamllint --strict ./ --format github
+          entrypoint: make
+          args: test-yaml

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,19 @@ update-deps:
 	tools/update-deps --cpanfile cpanfile
 
 .PHONY: test
-test: test-tidy test-author
+test: test-tidy test-critic test-yaml test-author
 
 .PHONY: test-tidy
 test-tidy:
 	tools/tidyall --all --check-only
+
+.PHONY: test-critic
+test-critic:
+	tools/perlcritic --quiet .
+
+.PHONY: test-yaml
+test-yaml:
+	yamllint --strict ./
 
 .PHONY: test-author
 test-author:


### PR DESCRIPTION
Having all usual checks available over the Makefile makes it easier for
developers to see what is available and call them.

Let me know what you think