### PR TITLE
Allow 'git subrepo clone' in commit messages

### DIFF
--- a/.github/workflows/base-commit-message-checker.yml
+++ b/.github/workflows/base-commit-message-checker.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check subject beginning
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^([A-Z]|\S+:|git subrepo pull)'
+          pattern: '^([A-Z]|\S+:|git subrepo (clone|pull))'
           flags: 'g'
           error: 'The subject does not start with a capital or tag.'
           excludeDescription: 'true'


### PR DESCRIPTION
I saw that the checker was complaining on https://github.com/os-autoinst/os-autoinst-distri-example/pull/31