### PR TITLE
"Revert" wording format should not count on character limit check

### DIFF
--- a/.github/workflows/base-commit-message-checker.yml
+++ b/.github/workflows/base-commit-message-checker.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check subject line length
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^((Revert )?.{1,72}(\n|$)|(Revert ").{1,72}"(\n|$))'
+          pattern: '^(Revert "?)?.{1,72}(\n|$)'
           flags: 'g'
           error: 'The maximum subject line length of 72 characters is exceeded.'
           excludeDescription: 'true'

--- a/.github/workflows/base-commit-message-checker.yml
+++ b/.github/workflows/base-commit-message-checker.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check subject line length
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^.{1,72}(\n|$)'
+          pattern: '^((Revert )?.{1,72}(\n|$)|(Revert ").{1,72}"(\n|$))'
           flags: 'g'
           error: 'The maximum subject line length of 72 characters is exceeded.'
           excludeDescription: 'true'


### PR DESCRIPTION
Right now, using Revert feature in UI or committing manually something with "Revert" word in addition, may trigger the check and block the merge of a time critical fix.

Example of issue: https://github.com/os-autoinst/os-autoinst-distri-opensuse/actions/runs/8076696536/job/22065582052

I try to allow both cases, with quoted commit (default from UI) and a manual commit that only adds Revert word and a space.

- Allow: <72chars>
- Allow: Revert<SPACE><72char>
- Allow: Revert<SPACE>"<72char>"  -> This is default format to revert using UI
- Do not allow: "<72char>"

Can be checked at https://regex101.com/

For your convenience, here are 72 chars for testing:
```
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
```