### PR TITLE
Fix error handling in `tools/tidyall`

### DIFF
--- a/tools/tidyall
+++ b/tools/tidyall
@@ -69,3 +69,4 @@ unless ($detected_version eq $required_version) {
 }
 
 exec 'tidyall', @tidyall_argv;
+exit 1;


### PR DESCRIPTION
* Exit with non-zero return code in case `exec` fails, e.g. if `tidyall` is not installed
* See https://progress.opensuse.org/issues/166817