### PR TITLE
Unify bash prove_wrapper

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -17,7 +17,7 @@ on 'develop' => sub {
     requires 'Code::TidyAll';
     requires 'Perl::Critic';
     requires 'Perl::Critic::Community';
-    requires 'Perl::Tidy', '== 20240511.0.0';
+    requires 'Perl::Tidy', '== 20250311';
 
 };
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -17,7 +17,7 @@ main_requires:
   perl(Module::CPANfile):
 
 develop_requires:
-  perl(Perl::Tidy): '== 20240511.0.0'
+  perl(Perl::Tidy): '== 20250311'
   perl(Code::TidyAll):
   perl(Perl::Critic):
   perl(Perl::Critic::Community):

--- a/tools/prove_wrapper
+++ b/tools/prove_wrapper
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -euo pipefail
+
+OUTPUT=$(mktemp)
+
+echo "Running prove with TAP output check ..."
+
+prove -I . "$@" 2>&1 | tee "$OUTPUT"
+STATUS=${PIPESTATUS[0]}
+
+if [ "$STATUS" -ne 0 ]; then
+    echo "not ok - prove failed"
+    exit "$STATUS"
+fi
+
+sed -E '
+  s/^\[[0-9]{2}:[0-9]{2}:[0-9]{2}\][[:space:]]*//
+  /^All tests successful\./,$d
+' "$OUTPUT" > "$OUTPUT.processed"
+
+UNHANDLED=$(grep -vE '^t/.*([0-9]{2}-|)([[:alnum:]]|_|-)+\.t \.+' "$OUTPUT.processed" || true)
+
+if [ -n "$UNHANDLED" ]; then
+    echo "not ok - unhandled output found"
+    echo "Run with PROVE_COMMAND=tools/prove_wrapper to reproduce locally"
+    exit 1
+else
+    echo "ok - no unhandled output found"
+    exit 0
+fi


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/181358

---

Since the prove_wrapper script is being use in both os-autoinst and openqa repository I'm moving that into here as discussed in https://github.com/os-autoinst/os-autoinst/pull/2701#discussion_r2089145960