### PR TITLE
HashKeyQuotes: keep quotes for keys that could be numbers

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -17,7 +17,7 @@ on 'develop' => sub {
     requires 'Code::TidyAll';
     requires 'Perl::Critic';
     requires 'Perl::Critic::Community';
-    requires 'Perl::Tidy', '== 20250311';
+    requires 'Perl::Tidy', '== 20250616';
 
 };
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -17,7 +17,7 @@ main_requires:
   perl(Module::CPANfile):
 
 develop_requires:
-  perl(Perl::Tidy): '== 20250311'
+  perl(Perl::Tidy): '== 20250616'
   perl(Code::TidyAll):
   perl(Perl::Critic):
   perl(Perl::Critic::Community):

--- a/lib/perlcritic/Perl/Critic/Policy/OpenQA/HashKeyQuotes.pm
+++ b/lib/perlcritic/Perl/Critic/Policy/OpenQA/HashKeyQuotes.pm
@@ -9,6 +9,7 @@ use experimental 'signatures';
 use base 'Perl::Critic::Policy';
 
 use Perl::Critic::Utils qw( :severities :classification :ppi );
+use Scalar::Util qw(looks_like_number);
 
 our $VERSION = '0.0.1';
 
@@ -29,6 +30,8 @@ sub violates ($self, $elem, $document) {
     my $k = $elem->can('literal') ? $elem->literal : $elem->string;
 
     # skip anything that has a special symbol in the content
+    return () if looks_like_number $k;
+    return () if $k =~ m/^[0-9_]+$/;
     return () unless $k =~ m/^\w+$/;
 
     # report violation

--- a/t/OpenQA/HashKeyQuotes.run
+++ b/t/OpenQA/HashKeyQuotes.run
@@ -8,6 +8,9 @@ $h{"line\nbreak"} = 2;
 $h{'special!'} = 3;
 $h{'concatenate_' . 'strings'} = 4;
 $h{bare2 } = 5;
+$h{"0123"} = 6;
+$h{"Inf"} = 7;
+$h{"3_14"} = 7;
 
 ## name Failing
 ## failures 4


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/179975