### PR TITLE
feat(prove_wrapper): Print test output immediately

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -23,6 +23,7 @@ develop_requires:
   perl(Perl::Critic::Community):
   perl(Test::Perl::Critic):
   python3-gitlint:
+  expect:  # for unbuffer
 
 cover_requires:
   perl(Devel::Cover):

--- a/tools/prove_wrapper
+++ b/tools/prove_wrapper
@@ -8,7 +8,11 @@ OUTPUT=$(mktemp)
 
 echo "Running prove with TAP output check ..."
 
-prove -I . "$@" 2>&1 | tee "$OUTPUT"
+# use unbuffer if available and stdout is a terminal for immediate output
+[[ -t 1 ]] && unbuffer_cmd=("$(which unbuffer 2>/dev/null)") || unbuffer_cmd=()
+
+"${unbuffer_cmd[@]}" prove -I . "$@" 2>&1 | tee "$OUTPUT"
+
 STATUS=${PIPESTATUS[0]}
 
 if [ "$STATUS" -ne 0 ]; then


### PR DESCRIPTION
`prove` switches from "line-buffered" mode to "block-buffered" mode due to the pipe. To retain "line-buffered" mode for immediate when stdout is a terminal, this change uses `unbuffer` from the `expect` package.

Related ticket: https://progress.opensuse.org/issues/182111

---

I tested test with an openQA test:

* It still complains if there's unhanded output.
* Output is written immediately when using a terminal.
* Unbuffer isn't used when redirecting to a file (so this is still as efficient as before when not using a terminal).
* It still works if `unbuffer` isn't installed.