### PR TITLE
ci: upgrade actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/base-commit-message-checker.yml
+++ b/.github/workflows/base-commit-message-checker.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install gitlint

--- a/.github/workflows/perl-author-tests.yml
+++ b/.github/workflows/perl-author-tests.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: |
           git config --system --add safe.directory "$GITHUB_WORKSPACE"
           make test-author

--- a/.github/workflows/perl-lint-checks.yml
+++ b/.github/workflows/perl-lint-checks.yml
@@ -12,5 +12,5 @@ jobs:
     container:
       image: registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: GITHUB_ACTIONS=1 make test-tidy

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,5 +11,5 @@ jobs:
     container:
       image: perldocker/perl-tester
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: make test-t

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
     name: "YAML-lint"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: docker://registry.opensuse.org/home/okurz/container/containers/tumbleweed:yamllint
         with:
           entrypoint: make


### PR DESCRIPTION
Why this change was needed:
The v4 version of actions/checkout is deprecated and will be unsupported on GitHub. It now throws warnings about the Node.js version being used, and GitHub plan removing support for it. This upgrade eliminates these warnings and ensures compatibility with current GitHub Actions infrastructure.

What changed:
- Updated all workflow files to use actions/checkout@v6
- Modified files: base-commit-message-checker.yml, perl-author-tests.yml, perl-lint-checks.yml, test.yaml, and yamllint.yml

Problem solved:
Workflows will no longer trigger deprecation warnings from GitHub Actions. Workflows remain compatible with GitHub's current infrastructure and best practices.