### PR TITLE
test(prove_wrapper): Skip check for unhandled output in verbose mode

### DIFF
--- a/tools/prove_wrapper
+++ b/tools/prove_wrapper
@@ -4,14 +4,19 @@
 
 set -euo pipefail
 
-OUTPUT=$(mktemp)
+prove_cmd=(prove -I .)
+
+# skip the check for unhandled output when running in verbose mode
+for arg in "$@"; do [[ $arg =~ (-v|--verbose) ]] && TEST_VERBOSE=1 && break; done
+[[ ${TEST_VERBOSE:-} && $TEST_VERBOSE != 0 ]] && exec "${prove_cmd[@]}" "$@"
 
 echo "Running prove with TAP output check ..."
 
 # use unbuffer if available and stdout is a terminal for immediate output
 [[ -t 1 ]] && unbuffer_cmd=("$(which unbuffer 2> /dev/null)") || unbuffer_cmd=()
 
-"${unbuffer_cmd[@]}" prove -I . "$@" 2>&1 | tee "$OUTPUT"
+OUTPUT=$(mktemp)
+"${unbuffer_cmd[@]}" "${prove_cmd[@]}" "$@" 2>&1 | tee "$OUTPUT"
 
 STATUS=${PIPESTATUS[0]}
 

--- a/tools/prove_wrapper
+++ b/tools/prove_wrapper
@@ -27,10 +27,9 @@ fi
 
 UNHANDLED=$(sed --regexp-extended \
     -e 's/^\[[0-9]{2}:[0-9]{2}:[0-9]{2}\][[:space:]]*//' \
-    -e '/^(x?t|t)\/.*\.t \.+/d' \
-    -e '/\s*(not )?ok/d' \
+    -e '/x?t\/.*\.t\s*\.+/d' \
+    -e '/\s*[0-9]+\.\.[0-9]+.*/d' \
     -e '/^# /d' \
-    -e '/^\s*[0-9]+\.\.[0-9]+.*/d' \
     -e '/Files=.*Tests=/d' \
     -e '/Result: /d' \
     -e '/All tests successful\./d' \


### PR DESCRIPTION
Checking for unhandled output is not possible in verbose mode because then stdout is not captured by `prove` (so we needed to deal with stdout as well in addition to stderr). So this change skips this check in verbose mode.

Related ticket: https://progress.opensuse.org/issues/182111