### PR TITLE
chore(README): Apply style changes from prettier used in qem-dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This repository is to be used as a
 [git-subrepo](https://github.com/ingydotnet/git-subrepo).
 
-
 `git-subrepo` is available in the following repositories:
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/git-subrepo.svg)](https://repology.org/project/git-subrepo/versions)
@@ -58,10 +57,10 @@ them and then do:
 ## git-subrepo
 
 You can find more information here:
-* [Repository and usage](https://github.com/ingydotnet/git-subrepo)
-* [A good comparison between subrepo, submodule and
-  subtree](https://github.com/ingydotnet/git-subrepo/blob/master/Intro.pod)
 
+- [Repository and usage](https://github.com/ingydotnet/git-subrepo)
+- [A good comparison between subrepo, submodule and
+  subtree](https://github.com/ingydotnet/git-subrepo/blob/master/Intro.pod)
 
 ## Development
 


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/182111

---

If that's wanted. I personally don't have anything against using `*` as bullet points and usually even prefer it but also don't really care. I would also nevertheless exclude this README in qem-dashboard because we shouldn't commonly have to rely on even more npm-based tooling - at least not for changes like that one which aren't really that useful.