### PR TITLE
fix: handle carriage returns and ANSI codes in prove_wrapper

### DIFF
--- a/tools/prove_wrapper
+++ b/tools/prove_wrapper
@@ -26,6 +26,8 @@ if [ "$STATUS" -ne 0 ]; then
 fi
 
 UNHANDLED=$(sed --regexp-extended \
+    -e 's/\x1b\[[0-9;]*[mK]//g' \
+    -e 's/\r//g' \
     -e 's/^\[[0-9]{2}:[0-9]{2}:[0-9]{2}\][[:space:]]*//' \
     -e '/x?t\/.*\.t\s*\.+/d' \
     -e '/\s*[0-9]+\.\.[0-9]+.*/d' \


### PR DESCRIPTION
Motivation:
Running `make -j test` in os-autoinst failed with "unhandled output
found" because `prove` output might contain carriage returns or ANSI
escape sequences (especially when using `unbuffer` or running in certain
terminal environments), which prevented the timestamp-stripping regex
from matching at the beginning of the line.

Design Choices:
1. Added `sed` rules to strip ANSI escape sequences (`\x1b[...]`) and
   carriage returns (`\r`) globally from each line before applying
   other filters.
2. Kept the existing regex for timestamps but ensured it now sees the
   actual beginning of the line after stripping control characters.

Benefits:
- `make -j test` (and parallel test execution in general) is more robust
  and less likely to fail due to harmless control characters in the
  output.
- Test output remains clean as these characters are filtered out before
  the "unhandled output" check.