### PR TITLE
feat: ensure TimeLimit::scale_timeout works without import

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     container:
-      image: perldocker/perl-tester
+      image: registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
     steps:
       - uses: actions/checkout@v6
       - run: make test-t

--- a/cpanfile
+++ b/cpanfile
@@ -8,6 +8,7 @@ requires 'Module::CPANfile';
 requires 'Storable', '>= 3.06';
 
 on 'test' => sub {
+    requires 'Test::Compile';
     requires 'Test::Most';
     requires 'Test::Warnings';
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -31,5 +31,6 @@ cover_requires:
   perl(Devel::Cover::Report::Codecov):
 
 test_requires:
+  perl(Test::Compile):
   perl(Test::Most):
   perl(Test::Warnings):

--- a/lib/OpenQA/Test/TimeLimit.pm
+++ b/lib/OpenQA/Test/TimeLimit.pm
@@ -4,23 +4,30 @@
 package OpenQA::Test::TimeLimit;
 use Test::Most;
 
-my $SCALE_FACTOR = $ENV{OPENQA_TEST_TIMEOUT_SCALE_FACTOR} // 1;
+my $SCALE_FACTOR;
 
-sub import {
-    my ($package, $limit) = @_;
-    die "$package: Need argument on import, e.g. use: use OpenQA::Test::TimeLimit '42';" unless $limit;
-    # disable timeout if requested by ENV variable or running within debugger
-    return if ($ENV{OPENQA_TEST_TIMEOUT_DISABLE} or $INC{'perl5db.pl'});
+sub _calculate_scale_factor {
+    return $SCALE_FACTOR if defined $SCALE_FACTOR;
+    $SCALE_FACTOR = $ENV{OPENQA_TEST_TIMEOUT_SCALE_FACTOR} // 1;
     $SCALE_FACTOR *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_COVER} // 3 if Devel::Cover->can('report');
     $SCALE_FACTOR *= $ENV{OPENQA_TEST_TIMEOUT_SCALE_CI} // 2 if $ENV{CI};
     $SCALE_FACTOR *= 5 if $ENV{HARNESS_IS_PARALLEL};
+    return $SCALE_FACTOR;
+}
+
+sub import {
+    my ($package, $limit) = @_;
+    _calculate_scale_factor();
+    return unless $limit;
+    # disable timeout if requested by ENV variable or running within debugger
+    return if ($ENV{OPENQA_TEST_TIMEOUT_DISABLE} or $INC{'perl5db.pl'});
     $limit *= $SCALE_FACTOR;
     $SIG{ALRM} = sub { BAIL_OUT "test '$0' exceeds runtime limit of '$limit' seconds\n" };
     alarm $limit;
 }
 
 sub scale_timeout {
-    return $_[0] * $SCALE_FACTOR;
+    return $_[0] * _calculate_scale_factor();
 }
 
 1;


### PR DESCRIPTION
Motivation:
Previously, OpenQA::Test::TimeLimit only initialized its internal
scaling factor if it was imported with a specific limit (e.g.
'use OpenQA::Test::TimeLimit "200"'). When used as a utility module
via 'OpenQA::Test::TimeLimit::scale_timeout', it would return
unscaled values because the initialization logic was skipped.

Design Choices:
- Refactor scaling factor calculation into a private
  _calculate_scale_factor method.
- Call this method from both 'import' and 'scale_timeout'.
- Use a state-like approach to cache the factor after first
  calculation.

Benefits:
- Enables reliable timeout scaling across the entire test suite,
  even when not using global test-wide alarms.
- Provides consistent behavior in slow environments like CI or
  when running coverage reports.