### PR TITLE
fix(prove_wrapper): Do not confuse test names with verbosity arguments

### DIFF
--- a/tools/prove_wrapper
+++ b/tools/prove_wrapper
@@ -7,7 +7,7 @@ set -euo pipefail
 prove_cmd=(prove -I .)
 
 # skip the check for unhandled output when running in verbose mode
-for arg in "$@"; do [[ $arg =~ (-v|--verbose) ]] && TEST_VERBOSE=1 && break; done
+for arg in "$@"; do [[ $arg =~ ^(-v|--verbose)$ ]] && TEST_VERBOSE=$arg && break; done
 [[ ${TEST_VERBOSE:-} && $TEST_VERBOSE != 0 ]] && exec "${prove_cmd[@]}" "$@"
 
 echo "Running prove with TAP output check ..."

--- a/tools/prove_wrapper
+++ b/tools/prove_wrapper
@@ -8,7 +8,10 @@ prove_cmd=(prove -I .)
 
 # skip the check for unhandled output when running in verbose mode
 for arg in "$@"; do [[ $arg =~ ^(-v|--verbose)$ ]] && TEST_VERBOSE=$arg && break; done
-[[ ${TEST_VERBOSE:-} && $TEST_VERBOSE != 0 ]] && exec "${prove_cmd[@]}" "$@"
+if [[ ${TEST_VERBOSE:-} && $TEST_VERBOSE != 0 ]]; then
+    echo "Skipping TAP output check as tests are running in verbose mode (arg/env: $TEST_VERBOSE) ..."
+    exec "${prove_cmd[@]}" "$@"
+fi
 
 echo "Running prove with TAP output check ..."
 


### PR DESCRIPTION
* Use anchors to avoid matching e.g. `t/16-utils-vcs-provider.t`
* Tested manually with tests from the openQA repo

Related ticket: https://progress.opensuse.org/issues/200934
Also see https://github.com/os-autoinst/openQA/pull/7523#issuecomment-4671268663