### PR TITLE
ci: automate Dependabot updates and auto-merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -36,9 +36,3 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-  - name: ask to resolve conflict
-    conditions:
-      - conflict
-    actions:
-      comment:
-        message: This pull request is now in conflicts. Could you fix it? 🙏

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -25,6 +25,17 @@ pull_request_rules:
     actions:
       merge:
         method: merge
+  - name: automatic merge for dependabot updates
+    conditions:
+      - base=master
+      - author=dependabot[bot]
+      - -label~=^acceptance-tests-needed|not-ready
+      - "#check-failure=0"
+      - "#check-pending=0"
+      - linear-history
+    actions:
+      merge:
+        method: squash
   - name: ask to resolve conflict
     conditions:
       - conflict


### PR DESCRIPTION
Motivation:
Automate GHA workflow updates via Dependabot and automatically squash-merge
them when CI passes to eliminate manual maintenance.

Design Choices:
Configured Dependabot for github-actions and added a squash auto-merge
Mergify rule for `dependabot[bot]`. Removed obsolete delayed-merge rules.

Benefits:
Saves maintainer time by fully automating dependency updates with high security
while preserving clean linear git history.